### PR TITLE
feat: minAmtPerSec per nftType 

### DIFF
--- a/src/nft.sol
+++ b/src/nft.sol
@@ -144,6 +144,10 @@ contract FundingNFT is ERC721, Ownable {
         }
 
         uint128 amtPerSec = pool.getAmtPerSecSubSender(address(this), tokenId);
+        if (amtPerSec == 0) {
+            return 0;
+        }
+
         uint128 secsLeft = currLeftSecsInCycle();
         uint128 neededCurrCycle = secsLeft * amtPerSec;
 

--- a/src/nft.sol
+++ b/src/nft.sol
@@ -138,15 +138,16 @@ contract FundingNFT is ERC721, Ownable {
     }
 
     function secsUntilInactive(uint tokenId) public view returns(uint128) {
+        if (nftTypes[tokenType(tokenId)].minAmtPerSec == 0) {
+            return type(uint128).max;
+        }
+
         uint128 amtNotStreamed = pool.withdrawableSubSender(address(this), tokenId);
         if (amtNotStreamed == 0) {
             return 0;
         }
 
         uint128 amtPerSec = pool.getAmtPerSecSubSender(address(this), tokenId);
-        if (amtPerSec == 0) {
-            return 0;
-        }
 
         uint128 secsLeft = currLeftSecsInCycle();
         uint128 neededCurrCycle = secsLeft * amtPerSec;

--- a/src/registry.sol
+++ b/src/registry.sol
@@ -9,18 +9,18 @@ contract RadicleRegistry {
     uint public counter;
 
     DaiPool public pool;
-    event NewProject(address indexed nftRegistry, address indexed projectOwner, uint128 minAmtPerSec);
+    event NewProject(address indexed nftRegistry, address indexed projectOwner);
 
     constructor (DaiPool pool_) {
         pool = pool_;
     }
 
-    function newProject(string memory name, string memory symbol, address projectOwner, uint128 minAmtPerSec, InputNFTType[] memory inputNFTTypes) public returns(address) {
+    function newProject(string memory name, string memory symbol, address projectOwner, InputNFTType[] memory inputNFTTypes) public returns(address) {
         counter++;
-        FundingNFT nftRegistry = new FundingNFT(pool, name, symbol, projectOwner, minAmtPerSec, inputNFTTypes);
+        FundingNFT nftRegistry = new FundingNFT(pool, name, symbol, projectOwner, inputNFTTypes);
         projects[counter] = address(nftRegistry);
 
-        emit NewProject(address(nftRegistry), projectOwner, minAmtPerSec);
+        emit NewProject(address(nftRegistry), projectOwner);
         return address(nftRegistry);
     }
 }

--- a/src/test/nft.t.sol
+++ b/src/test/nft.t.sol
@@ -230,9 +230,9 @@ contract NFTRegistryTest is BaseTest {
         addNFTType(nftType, limit, minAmtPerSec);
         uint128 amount = 30 ether;
         dai.approve(nftRegistry_, uint(amount));
-        uint tokenId = nftRegistry.mint(address(this), nftType, amount, defaultMinAmtPerSec);
+        uint tokenId = nftRegistry.mint(address(this), nftType, amount, minAmtPerSec);
 
-        assertTrue(nftRegistry.secsUntilInactive(tokenId) != 0);
+        assertEq(nftRegistry.secsUntilInactive(tokenId), type(uint128).max);
     }
 
     function testTopUp() public {

--- a/src/test/nft.t.sol
+++ b/src/test/nft.t.sol
@@ -223,6 +223,18 @@ contract NFTRegistryTest is BaseTest {
         assertEq(nftRegistry.withdrawable(tokenId), amount-totalStreamed, "incorrect-withdrawable-amount");
     }
 
+    function testZeroAmtPerSec() public {
+        uint128 nftType = 2;
+        uint64 limit = 100;
+        uint128 minAmtPerSec = 0;
+        addNFTType(nftType, limit, minAmtPerSec);
+        uint128 amount = 30 ether;
+        dai.approve(nftRegistry_, uint(amount));
+        uint tokenId = nftRegistry.mint(address(this), nftType, amount, defaultMinAmtPerSec);
+
+        assertTrue(nftRegistry.secsUntilInactive(tokenId) != 0);
+    }
+
     function testTopUp() public {
         uint128 initial = 30 ether;
         dai.approve(address(nftRegistry), initial);

--- a/src/test/registry.t.sol
+++ b/src/test/registry.t.sol
@@ -22,23 +22,24 @@ contract RegistryTest is BaseTest {
     }
 
     function testNewNFTRegistry() public {
-        uint128 minAmtPerSec = uint128(fundingInSeconds(10 ether));
         string memory name = "First Funding Project";
         string memory symbol = "FFP";
-        uint128 limitTypeZero = 10;
-        uint128 limitTypeOne = 20;
+        uint64 limitTypeZero = 100;
+        uint64 limitTypeOne = 200;
 
         InputNFTType[] memory nftTypes = new InputNFTType[](2);
-        nftTypes[0] = InputNFTType({nftTypeId: 0, limit:limitTypeZero});
-        nftTypes[1] = InputNFTType({nftTypeId: 1, limit:limitTypeOne});
+        nftTypes[0] = InputNFTType({nftTypeId: 0, limit:limitTypeZero, minAmtPerSec: 10});
+        nftTypes[1] = InputNFTType({nftTypeId: 1, limit:limitTypeOne, minAmtPerSec: 20});
 
-        address nftRegistry_ = radicleRegistry.newProject(name, symbol, address(0xA), minAmtPerSec, nftTypes);
+        address nftRegistry_ = radicleRegistry.newProject(name, symbol, address(0xA), nftTypes);
         FundingNFT nftRegistry = FundingNFT(nftRegistry_);
         assertEq(nftRegistry.owner(), address(0xA));
         assertEq(radicleRegistry.projects(1), nftRegistry_);
-        (uint128 limit, uint128 minted) = nftRegistry.nftTypes(0);
+        (uint64 limit, uint64 minted, uint128 minAmtPerSec) = nftRegistry.nftTypes(0);
         assertEq(limit, limitTypeZero);
-        (limit, minted) = nftRegistry.nftTypes(1);
+        assertEq(minAmtPerSec, 10);
+        (limit, minted, minAmtPerSec) = nftRegistry.nftTypes(1);
         assertEq(limit, limitTypeOne);
+        assertEq(minAmtPerSec, 20);
     }
 }


### PR DESCRIPTION
- different minAmtPerSec for each NFT type
- reduced limit and mint to uint64 for storage optimization (allows 2^64 potential NFTs per type)