### PR TITLE
Fix linter warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
         run: nix-shell --run "make install"
       - name: lint
         run: nix-shell --run "make lint"
-        continue-on-error: true
       - name: test
         if: ${{ github.event_name == 'pull_request' }}
         run: nix-shell --run "make test"

--- a/src/base64.sol
+++ b/src/base64.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.7;
 
 library Base64 {
-    string internal constant TABLE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+    string internal constant TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     function encode(bytes memory data) internal pure returns (string memory) {
-        if (data.length == 0) return '';
+        if (data.length == 0) return "";
 
         // load the table into memory
         string memory table = TABLE;
@@ -15,6 +15,7 @@ library Base64 {
         // add some extra buffer at the end required for the writing
         string memory result = new string(encodedLen + 32);
 
+        // solhint-disable-next-line no-inline-assembly
         assembly {
         // set the actual output length
             mstore(result, encodedLen)
@@ -30,6 +31,7 @@ library Base64 {
             let resultPtr := add(result, 32)
 
         // run over the input, 3 bytes at a time
+        // solhint-disable-next-line no-empty-blocks
             for {} lt(dataPtr, endPtr) {}
             {
                 dataPtr := add(dataPtr, 3)

--- a/src/metadata.sol
+++ b/src/metadata.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+// solhint-disable quotes
 pragma solidity ^0.8.7;
 import "./base64.sol";
 import "openzeppelin-contracts/utils/Strings.sol";

--- a/src/nft.sol
+++ b/src/nft.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.7;
 
 import {ERC721} from "openzeppelin-contracts/token/ERC721/ERC721.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";

--- a/src/test/nft.t.sol
+++ b/src/test/nft.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.7;
 
 import "ds-test/test.sol";
 import "./../nft.sol";
@@ -14,10 +14,10 @@ contract TestDai is Dai {
 }
 
 contract NFTRegistryTest is BaseTest {
-    FundingNFT nftRegistry;
-    address nftRegistry_;
-    DaiPool pool;
-    TestDai dai;
+    FundingNFT public nftRegistry;
+    address public nftRegistry_;
+    DaiPool public pool;
+    TestDai public dai;
     Hevm public hevm;
 
     uint constant public ONE_TRILLION_DAI = (1 ether * 10**12);

--- a/src/test/registry.t.sol
+++ b/src/test/registry.t.sol
@@ -9,8 +9,8 @@ import {Dai} from "../../lib/radicle-streaming/src/test/TestDai.sol";
 import "../../lib/radicle-streaming/src/test/BaseTest.t.sol";
 
 contract RegistryTest is BaseTest {
-    RadicleRegistry radicleRegistry;
-    DaiPool pool;
+    RadicleRegistry public radicleRegistry;
+    DaiPool public pool;
     Dai public dai;
     Hevm public hevm;
 


### PR DESCRIPTION
Depends on https://github.com/radicle-dev/funding-contracts/pull/28. Fixes linter warnings and makes CI require no linter warnings.