### PR TITLE
Remove data struct

### DIFF
--- a/src/test/builder.t.sol
+++ b/src/test/builder.t.sol
@@ -27,11 +27,11 @@ contract BuilderTest is DSTest {
         assertEq(builder.toTwoDecimals(12.0149 * 10**18), "12.01", "incorrect-number-string");
     }
 
-    function testSVGJSON() public {
+    function testSVGJSON() public view {
         builder.buildMetaData("Test", 1, 5 ether, true);
     }
 
-    function testIPFSJSON() public {
+    function testIPFSJSON() public view {
         builder.buildMetaData("Test", 1, 5 ether, true, "ipfsHash");
     }
 


### PR DESCRIPTION
Remove `struct Data` from `Builder`. IMO it clarifies code and naturally makes it flatter. Fixed function visibility warnings.